### PR TITLE
fixing brew install script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,7 @@ echo -e "\e[32mInstall software\e[m"
 if $ISMAC; then
     echo "Install homebrew"
     if ! { type brew > /dev/null 2>&1; }; then
-        /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)" 
     fi
 
     echo "Install cask"


### PR DESCRIPTION
# Fixing brew install script
## TL;DR
- replaced the obsoleted ruby installer to bash installer
- https://github.com/Abemii/dotfiles/issues/2

## References
- https://github.com/Homebrew/install/blob/master/install
  >  Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
Bash.  
- https://brew.sh/index_ja
